### PR TITLE
Add missing deps + add webpack to test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node server/index.js",
     "less": "lessc src/css/style.less dist/css/style.css",
     "lint": "eslint .",
-    "test": "mocha test/.setup.js test/*.spec.js"
+    "test": "npm run build && mocha test/.setup.js test/*.spec.js"
   },
   "dependencies": {
     "axios": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "axios-mock-adapter": "^1.6.1",
     "babel": "^6.3.26",
+    "babel-loader": "^7.1.1",
     "babel-preset-airbnb": "^1.0.1",
     "babel-register": "^6.4.3",
     "chai-as-promised": "^5.3.0",
@@ -41,13 +42,14 @@
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-lodash-fp": "^2.1.3",
     "eslint-plugin-react": "^6.2.0",
+    "file-loader": "^0.11.2",
     "less": "^2.7.1",
     "less-plugin-autoprefix": "^1.5.1",
     "mocha": "^3.0.2",
     "react-addons-test-utils": "^15.6.0",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
-    "url-loader": "^0.5.7"
+    "url-loader": "^0.5.9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request adds `babel-loader`, `file-loader` and `url-loader` as dependencies, and triggers a webpack build before running tests.